### PR TITLE
remove accessing to state by references, clear profile data after logout

### DIFF
--- a/src/components/notification.vue
+++ b/src/components/notification.vue
@@ -2,7 +2,7 @@
     <div>
         <div ref="alert" class="alert alert-dismissible fade" :class="{'alert-danger':is_error, 'alert-success':!is_error, 'show':show, 'd-none':!show}">
             <strong>{{message}}</strong>
-            <button v-on:click="hide" class="btn-close"></button>
+            <button v-on:click="clear" class="btn-close"></button>
         </div>
     </div>
 </template>
@@ -19,8 +19,13 @@ export default defineComponent({
     },
     methods:{
         ...mapMutations('notification', [
-            'hide'
+            'clear'
         ])
+    },
+    watch:{
+        $route: function(newVal, oldVal){
+            this.clear()
+        }
     }
 })
 </script>

--- a/src/components/personalDetails.vue
+++ b/src/components/personalDetails.vue
@@ -63,7 +63,14 @@ import '@/types/PersonalDetails'
 export default defineComponent({
   data(){
     return{
-      personal_details_copy: {} as PersonalDetails
+      personal_details_copy: <PersonalDetails>{}
+    }
+  },
+  watch:{
+    personal_details: function(newVal, oldVal){
+      console.log('watch details');
+      
+      this.personal_details_copy = Object.assign(this.personal_details_copy, newVal)
     }
   },
   computed:{
@@ -86,8 +93,6 @@ export default defineComponent({
   mounted(){
     //way to get clone of a OBJECT, not reference 
     Object.assign(this.personal_details_copy, this.personal_details)
-    
-    
   }
 })
 </script>

--- a/src/components/userLocations.vue
+++ b/src/components/userLocations.vue
@@ -144,6 +144,14 @@ export default defineComponent({
             user_locations_copy: {} as UserLocation[]
         }
     },
+    watch:{
+        user_locations: {
+            handler(newVal){
+                this.user_locations_copy = JSON.parse(JSON.stringify(newVal))
+            },
+            deep: true,
+        }
+    },
     computed:{
         ...mapGetters('profile', [
             'channels',
@@ -164,22 +172,15 @@ export default defineComponent({
         UPDATE(location: UserLocation){
             this.UPDATE_USER_LOCATION(location)
             .catch(()=>{
-                var index = _.findIndex(this.user_locations, {id: location.id});
-                var index_copy = _.findIndex(this.user_locations_copy, {id: location.id});
-                Object.assign(this.user_locations_copy[index_copy], this.user_locations[index]) 
+                this.user_locations_copy = JSON.parse(JSON.stringify(this.user_locations))
             })
         },
         DELETE(location: UserLocation){
             this.DELETE_USER_LOCATION(location)
-            .then(()=>{
-                _.remove(this.user_locations_copy, {id: location.id})
-            })
         },
         ADD(){
             this.ADD_USER_LOCATION(this.new_location)
-            .then((response)=>{
-                this.new_location.id = response.data.id
-                this.user_locations_copy.push(this.new_location)
+            .then(()=>{
                 this.new_location = {
                     title: ''
                 } as UserLocation

--- a/src/libraries/store/modules/notification/mutations.ts
+++ b/src/libraries/store/modules/notification/mutations.ts
@@ -10,7 +10,9 @@ export default {
       state.is_error = true
       state.message = message??'Some error occued'
     },
-    hide(state: NotificationState){
+    clear(state: NotificationState){
+      state.is_error = false
+      state.message = ""
       state.show = false
     }
 }

--- a/src/libraries/store/modules/profile/mutations.ts
+++ b/src/libraries/store/modules/profile/mutations.ts
@@ -40,5 +40,20 @@ export default {
     },
     setLocations(state: ProfileState, locations: UserLocation[]){
       state.user_locations = locations
+    },
+    clear(state: ProfileState){
+      state = {
+        avatar: null,
+        channels: {
+          tg: "",
+          email: ""
+        },
+        personal_details:{
+          firstname: "",
+          lastname: "",
+          language: ""
+        },
+        user_locations: [] as UserLocation[]
+      }
     }
 }

--- a/src/libraries/store/modules/user/actions.ts
+++ b/src/libraries/store/modules/user/actions.ts
@@ -48,6 +48,8 @@ export default {
       })
     },
     LOGOUT(context: any) {
+      context.commit("profile/clear", null, { root: true })
+      context.commit("notification/clear", null, { root: true })
       context.commit("logout")
       router.push({ name: 'index'})
     }

--- a/src/libraries/store/modules/user/mutations.ts
+++ b/src/libraries/store/modules/user/mutations.ts
@@ -9,6 +9,7 @@ export default {
     logout(state: UserState) {
       state.session_key = {} as string
       sessionStorage.removeItem("sessionKey")
+      delete axios.defaults.headers.common["Authorization"]
       state.is_auth = false
     }
 }

--- a/src/views/profile.vue
+++ b/src/views/profile.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="profile" class="d-flex flex-column" style="min-height: 100vh;">
+  <div id="profile" class="d-flex flex-column" style="min-height: 100vh;" v-if="init">
     <header>
 			<navbar-component></navbar-component>
 		</header>
@@ -15,14 +15,14 @@
           <avatar-component></avatar-component>
         </div>
         <div class="col-7 px-4">
-          <profile-details v-if="personal_details"></profile-details>
+          <profile-details></profile-details>
         </div>
       </div>
       <div class="row">
-        <profile-locations v-if="user_locations&&channels&&locations"></profile-locations>
+        <profile-locations></profile-locations>
       </div>
       <div class="row">
-        <channels-component v-if="channels"></channels-component>
+        <channels-component></channels-component>
       </div>
     </main>
     <footer-component></footer-component>
@@ -52,7 +52,8 @@ export default defineComponent({
   data() {
     return {
       message: "",
-      error: false 
+      error: false,
+      init: false
     }
   },
   computed:{
@@ -89,7 +90,9 @@ export default defineComponent({
       this.FETCH_DETAILS(),
       this.FETCH_CHANNELS(),
       this.FETCH_USER_LOCATIONS()
-    ])
+    ]).then(()=>{
+      this.init = true
+    })
   }
 })
 </script>


### PR DESCRIPTION
Clear profile data after logout in state
Remove accessing to state by references. I mean, because all objects in js passing by reference, when local copy , for example, of personal_details changed, it also changed in state (without api call), so not real data was saved in state.
I tried to fix it before, but it worked not properly.
I use watchers now, you can learn more about it by clicking the link(https://v3.vuejs.org/guide/computed.html#watchers)

I hope more detailed discriptions help to figure out with thinks, that happen on frontend (and improve my english skills)